### PR TITLE
Move to parity v1.9.1

### DIFF
--- a/chains/docker-compose.yml
+++ b/chains/docker-compose.yml
@@ -4,10 +4,10 @@ services:
   parity_eth:
     container_name: parity_eth
     restart: always
-    image: parity/parity:stable
+    image: parity/parity:v1.9.1
     ports:
       - "8545:8545"
-    command: "--db-path /cyberdata --jsonrpc-hosts all --jsonrpc-interface all --jsonrpc-threads 4"
+    command: "--base-path /cyberdata --jsonrpc-hosts all --jsonrpc-interface all --jsonrpc-threads 4"
     volumes:
       - /cyberdata/eth:/cyberdata
 


### PR DESCRIPTION
We've got corrupted DB with Parity 1.8.7 right now:

    2018-02-01 11:19:43 UTC Keys path /root/.local/share/io.parity.ethereum/keys/Foundation
    2018-02-01 11:19:43 UTC DB path /cyberdata/ethereum/db/906a34e69aec8c0d
    2018-02-01 11:19:43 UTC Path to dapps /root/.local/share/io.parity.ethereum/dapps
    2018-02-01 11:19:43 UTC State DB configuration: fast
    2018-02-01 11:19:43 UTC Operating mode: active
    2018-02-01 11:19:43 UTC Configured for Foundation using Ethash engine
    2018-02-01 11:19:43 UTC DB corrupted: Invalid argument: You have to open all column families. Column families not opened: col6, col4, col5, col1, col0, col2, col3, attempting repair
    2018-02-01 11:19:43 UTC Updated conversion rate to Ξ1 = US$1095.17 (108702400 wei/gas)
    Client service error: Client(Database("Received null column family handle from DB."))

Switching to v1.9.x whith improved DB corruption recovery
https://github.com/paritytech/parity/blob/master/CHANGELOG.md