### PR TITLE
Migrate search kafka monitoring info to kafka exporter metrics

### DIFF
--- a/kubernetes-definitions/monitoring/dashboards/bitcoin/BTC_Contract_Summary.json
+++ b/kubernetes-definitions/monitoring/dashboards/bitcoin/BTC_Contract_Summary.json
@@ -19,6 +19,169 @@
   "links": [],
   "panels": [
     {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "id": 14,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "Locks",
+      "prefixFontSize": "70%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(contract_summary_apply_lock_counter_total{chain=\"BITCOIN\", topic=\"BITCOIN_TX_PUMP\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Apply Tx Locks",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "format": "short",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "id": 22,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "Remaining",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"BITCOIN_TX_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"bitcoin-contract-summary-update-process\",topic=\"BITCOIN_TX_PUMP\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Tx Offsets To Apply Remaining",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "100,1000",
+      "title": "Tx Offsets To Apply Remaining",
+      "type": "singlestat",
+      "valueFontSize": "50%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -29,7 +192,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 0
+        "y": 3
       },
       "id": 31,
       "legend": {
@@ -109,7 +272,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 0
+        "y": 3
       },
       "id": 2,
       "legend": {
@@ -135,7 +298,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(contract_summary_topic_current_offset{chain=\"BITCOIN\",topic=\"BITCOIN_TX_PUMP\"})",
+          "expr": "sum(kafka_consumergroup_current_offset{consumergroup=\"bitcoin-contract-summary-update-process\",topic=\"BITCOIN_TX_PUMP\"})",
           "format": "time_series",
           "interval": "20s",
           "intervalFactor": 1,
@@ -143,19 +306,12 @@
           "refId": "A"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"BITCOIN\",topic=\"BITCOIN_TX_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"BITCOIN_TX_PUMP\"})",
           "format": "time_series",
           "interval": "20s",
           "intervalFactor": 1,
           "legendFormat": "Bitcoin Txs Contract Summary Last Offset",
           "refId": "B"
-        },
-        {
-          "expr": "sum(pump_topic_last_offset{chain=\"BITCOIN\",topic=\"BITCOIN_TX_PUMP\"}) - sum(contract_summary_topic_current_offset{chain=\"BITCOIN\",topic=\"BITCOIN_TX_PUMP\"})",
-          "format": "time_series",
-          "hide": true,
-          "intervalFactor": 1,
-          "refId": "C"
         }
       ],
       "thresholds": [
@@ -213,666 +369,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 9
-      },
-      "id": 4,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(contract_summary_topic_current_offset{chain=\"BITCOIN\",topic=\"BITCOIN_BLOCK_PUMP\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Current Contract Summary Block Offset",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(pump_topic_last_offset{chain=\"BITCOIN\",topic=\"BITCOIN_BLOCK_PUMP\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Last Contract Summary Bitcoin Block Offset",
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Last Applied Block Offset",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "PROMETHEUS",
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 9
-      },
-      "id": 6,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(contract_summary_topic_current_offset{chain=\"BITCOIN\",topic=\"BITCOIN_UNCLE_PUMP\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Current Contract Summary Uncle Offset",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(pump_topic_last_offset{chain=\"BITCOIN\",topic=\"BITCOIN_UNCLE_PUMP\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Last Contract Summary Uncle Offset",
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Last Applied Uncle Offset",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "PROMETHEUS",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 0,
-        "y": 18
-      },
-      "id": 14,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "Locks",
-      "prefixFontSize": "70%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(contract_summary_apply_lock_counter_total{chain=\"BITCOIN\", topic=\"BITCOIN_TX_PUMP\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "title": "Apply Tx Locks",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "PROMETHEUS",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 4,
-        "y": 18
-      },
-      "id": 16,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "Locks",
-      "prefixFontSize": "70%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(contract_summary_apply_lock_counter_total{chain=\"BITCOIN\", topic=\"BITCOIN_BLOCK_PUMP\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "title": "Apply Block Locks",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "PROMETHEUS",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 8,
-        "y": 18
-      },
-      "id": 18,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "Locks",
-      "prefixFontSize": "70%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(contract_summary_apply_lock_counter_total{chain=\"BITCOIN\", topic=\"BITCOIN_UNCLE_PUMP\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "title": "Apply Uncle Locks",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": true,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "PROMETHEUS",
-      "decimals": null,
-      "format": "short",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 12,
-        "y": 18
-      },
-      "id": 22,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "Remaining",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(pump_topic_last_offset{chain=\"BITCOIN\",topic=\"BITCOIN_TX_PUMP\"}) - sum(contract_summary_topic_current_offset{chain=\"BITCOIN\",topic=\"BITCOIN_TX_PUMP\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Tx Offsets To Apply Remaining",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "100,1000",
-      "title": "Tx Offsets To Apply Remaining",
-      "type": "singlestat",
-      "valueFontSize": "50%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": true,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "PROMETHEUS",
-      "format": "short",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 16,
-        "y": 18
-      },
-      "id": 20,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "Remaining",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(pump_topic_last_offset{chain=\"BITCOIN\",topic=\"BITCOIN_BLOCK_PUMP\"}) - sum(contract_summary_topic_current_offset{chain=\"BITCOIN\",topic=\"BITCOIN_BLOCK_PUMP\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Block Offsets To Apply Remaining",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "1,5",
-      "title": "Block Offsets To Apply Remaining",
-      "type": "singlestat",
-      "valueFontSize": "50%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": true,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "PROMETHEUS",
-      "format": "short",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 20,
-        "y": 18
-      },
-      "id": 24,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "Remaining",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(pump_topic_last_offset{chain=\"BITCOIN\",topic=\"BITCOIN_UNCLE_PUMP\"}) - sum(contract_summary_topic_current_offset{chain=\"BITCOIN\",topic=\"BITCOIN_UNCLE_PUMP\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Uncle Offsets To Apply Remaining",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "1,5",
-      "title": "Uncle Offsets To Apply Remaining",
-      "type": "singlestat",
-      "valueFontSize": "50%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "PROMETHEUS",
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 21
+        "y": 12
       },
       "id": 29,
       "legend": {
@@ -953,7 +450,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 21
+        "y": 12
       },
       "id": 27,
       "legend": {
@@ -1034,7 +531,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 30
+        "y": 21
       },
       "id": 26,
       "legend": {
@@ -1115,7 +612,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 30
+        "y": 21
       },
       "id": 28,
       "legend": {

--- a/kubernetes-definitions/monitoring/dashboards/bitcoin/BTC_Dump.json
+++ b/kubernetes-definitions/monitoring/dashboards/bitcoin/BTC_Dump.json
@@ -19,6 +19,328 @@
   "links": [],
   "panels": [
     {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "PROMETHEUS",
+      "format": "short",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "id": 8,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "Remaining",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"BITCOIN_TX_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"bitcoin-txs-dump-process\",topic=\"BITCOIN_TX_PUMP\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Tx Offsets To Dump Remaining",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "100,1000",
+      "title": "Tx Offsets To Dump Remaining",
+      "type": "singlestat",
+      "valueFontSize": "50%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "PROMETHEUS",
+      "format": "s",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "id": 12,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "(sum(kafka_topic_partition_current_offset{topic=\"BITCOIN_TX_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"bitcoin-txs-dump-process\", topic=\"BITCOIN_TX_PUMP\"})) / sum(rate(kafka_consumergroup_current_offset{consumergroup=\"bitcoin-txs-dump-process\", topic=\"BITCOIN_TX_PUMP\"}[10m]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Tx Dump Remaining Time",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "PROMETHEUS",
+      "format": "short",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "id": 10,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "Remaining",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"BITCOIN_BLOCK_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"bitcoin-blocks-dump-process\",topic=\"BITCOIN_BLOCK_PUMP\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Block Offsets To Dump Remaining",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "1,5",
+      "title": "Block Offsets To Dump Remaining",
+      "type": "singlestat",
+      "valueFontSize": "50%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "PROMETHEUS",
+      "format": "s",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "id": 14,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "(sum(kafka_topic_partition_current_offset{topic=\"BITCOIN_BLOCK_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"bitcoin-blocks-dump-process\", topic=\"BITCOIN_BLOCK_PUMP\"})) / sum(rate(kafka_consumergroup_current_offset{consumergroup=\"bitcoin-blocks-dump-process\", topic=\"BITCOIN_BLOCK_PUMP\"}[10m]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Block Dump Remaining Time",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -29,7 +351,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 0
+        "y": 3
       },
       "id": 6,
       "legend": {
@@ -55,25 +377,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(dump_topic_current_offset{chain=\"BITCOIN\",topic=\"BITCOIN_TX_PUMP\"})",
+          "expr": "sum(kafka_consumergroup_current_offset{consumergroup=\"bitcoin-txs-dump-process\",topic=\"BITCOIN_TX_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Current Dump Tx Offset",
           "refId": "A"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"BITCOIN\",topic=\"BITCOIN_TX_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"BITCOIN_TX_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Last Dump Tx Offset",
           "refId": "B"
-        },
-        {
-          "expr": "sum(pump_topic_last_offset{chain=\"BITCOIN\",topic=\"BITCOIN_TX_PUMP\"}) - sum(dump_topic_current_offset{chain=\"BITCOIN\",topic=\"BITCOIN_TX_PUMP\"})",
-          "format": "time_series",
-          "hide": true,
-          "intervalFactor": 1,
-          "refId": "C"
         }
       ],
       "thresholds": [
@@ -121,250 +436,6 @@
       ]
     },
     {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": true,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "PROMETHEUS",
-      "format": "short",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 12,
-        "y": 0
-      },
-      "id": 8,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "Remaining",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(pump_topic_last_offset{chain=\"BITCOIN\",topic=\"BITCOIN_TX_PUMP\"}) - sum(dump_topic_current_offset{chain=\"BITCOIN\",topic=\"BITCOIN_TX_PUMP\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Tx Offsets To Dump Remaining",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "100,1000",
-      "title": "Tx Offsets To Dump Remaining",
-      "type": "singlestat",
-      "valueFontSize": "50%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": true,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "PROMETHEUS",
-      "format": "short",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 16,
-        "y": 0
-      },
-      "id": 10,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "Remaining",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(pump_topic_last_offset{chain=\"BITCOIN\",topic=\"BITCOIN_BLOCK_PUMP\"}) - sum(dump_topic_current_offset{chain=\"BITCOIN\",topic=\"BITCOIN_BLOCK_PUMP\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Block Offsets To Dump Remaining",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "1,5",
-      "title": "Block Offsets To Dump Remaining",
-      "type": "singlestat",
-      "valueFontSize": "50%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": true,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "PROMETHEUS",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 20,
-        "y": 0
-      },
-      "id": 12,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "Remaining",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(pump_topic_last_offset{chain=\"BITCOIN\",topic=\"BITCOIN_UNCLE_PUMP\"}) - sum(dump_topic_current_offset{chain=\"BITCOIN\",topic=\"BITCOIN_UNCLE_PUMP\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Uncle Offsets To Dump Remaining",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "1,5",
-      "timeShift": null,
-      "title": "Uncle Offsets To Dump Remaining",
-      "type": "singlestat",
-      "valueFontSize": "50%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -377,7 +448,7 @@
         "x": 12,
         "y": 3
       },
-      "id": 2,
+      "id": 4,
       "legend": {
         "avg": false,
         "current": false,
@@ -401,24 +472,24 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(dump_topic_current_offset{chain=\"BITCOIN\",topic=\"BITCOIN_UNCLE_PUMP\"})",
+          "expr": "sum(kafka_consumergroup_current_offset{consumergroup=\"bitcoin-blocks-dump-process\",topic=\"BITCOIN_BLOCK_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Current Dump Uncle Offset",
+          "legendFormat": "Current Dump Block Offset",
           "refId": "A"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"BITCOIN\",topic=\"BITCOIN_UNCLE_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"BITCOIN_BLOCK_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Last Uncle Offset",
+          "legendFormat": "Last Block Offset",
           "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Last Dumped Uncle Offset",
+      "title": "Last Dumped Block Offset",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -461,10 +532,10 @@
       "gridPos": {
         "h": 9,
         "w": 12,
-        "x": 0,
-        "y": 9
+        "x": 6,
+        "y": 12
       },
-      "id": 4,
+      "id": 2,
       "legend": {
         "avg": false,
         "current": false,
@@ -488,24 +559,24 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(dump_topic_current_offset{chain=\"BITCOIN\",topic=\"BITCOIN_BLOCK_PUMP\"})",
+          "expr": "rate(kafka_consumergroup_current_offset{consumergroup=\"bitcoin-txs-dump-process\", topic=\"BITCOIN_TX_PUMP\"}[1h])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Current Dump Block Offset",
+          "legendFormat": "Tx Records",
           "refId": "A"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"BITCOIN\",topic=\"BITCOIN_BLOCK_PUMP\"})",
+          "expr": "rate(kafka_consumergroup_current_offset{consumergroup=\"bitcoin-blocks-dump-process\", topic=\"BITCOIN_BLOCK_PUMP\"}[1h])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Last Block Offset",
+          "legendFormat": "Block Records",
           "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Last Dumped Block Offset",
+      "title": "Dump Records Per Second",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/kubernetes-definitions/monitoring/dashboards/bitcoin/BTC_Pump.json
+++ b/kubernetes-definitions/monitoring/dashboards/bitcoin/BTC_Pump.json
@@ -713,6 +713,166 @@
           "show": true
         }
       ]
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "PROMETHEUS",
+      "format": "decbytes",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 7,
+        "y": 19
+      },
+      "id": 20,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(txs_outputs_cache_size_bytes{chain = \"BITCOIN\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Cache size",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "PROMETHEUS",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 11,
+        "y": 19
+      },
+      "id": 22,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(txs_outputs_cache_items{chain = \"BITCOIN\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Cache items count",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
     }
   ],
   "refresh": "5s",

--- a/kubernetes-definitions/monitoring/dashboards/ethereum/ETH_Contract_Summary.json
+++ b/kubernetes-definitions/monitoring/dashboards/ethereum/ETH_Contract_Summary.json
@@ -168,7 +168,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(contract_summary_topic_current_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_TX_PUMP\"})",
+          "expr": "sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-contract-summary-update-process\",topic=\"ETHEREUM_TX_PUMP\"})",
           "format": "time_series",
           "interval": "20s",
           "intervalFactor": 1,
@@ -176,7 +176,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_TX_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_TX_PUMP\"})",
           "format": "time_series",
           "interval": "20s",
           "intervalFactor": 1,
@@ -184,7 +184,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_TX_PUMP\"}) - sum(contract_summary_topic_current_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_TX_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_TX_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-contract-summary-update-process\",topic=\"ETHEREUM_TX_PUMP\"})",
           "format": "time_series",
           "hide": true,
           "intervalFactor": 1,
@@ -306,21 +306,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(contract_summary_topic_current_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_BLOCK_PUMP\"})",
+          "expr": "sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-contract-summary-update-process\",topic=\"ETHEREUM_BLOCK_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Current Contract Summary Block Offset",
           "refId": "A"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_BLOCK_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_BLOCK_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Last Contract Summary Ethereum Block Offset",
           "refId": "B"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_BLOCK_PUMP\"}) - sum(contract_summary_topic_current_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_BLOCK_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_BLOCK_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-contract-summary-update-process\",topic=\"ETHEREUM_BLOCK_PUMP\"})",
           "format": "time_series",
           "hide": true,
           "intervalFactor": 1,
@@ -442,21 +442,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(contract_summary_topic_current_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_UNCLE_PUMP\"})",
+          "expr": "sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-contract-summary-update-process\",topic=\"ETHEREUM_UNCLE_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Current Contract Summary Uncle Offset",
           "refId": "A"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_UNCLE_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_UNCLE_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Last Contract Summary Uncle Offset",
           "refId": "B"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_UNCLE_PUMP\"}) - sum(contract_summary_topic_current_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_UNCLE_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_UNCLE_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-contract-summary-update-process\",topic=\"ETHEREUM_UNCLE_PUMP\"})",
           "format": "time_series",
           "hide": true,
           "intervalFactor": 1,
@@ -811,7 +811,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_TX_PUMP\"}) - sum(contract_summary_topic_current_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_TX_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_TX_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-contract-summary-update-process\",topic=\"ETHEREUM_TX_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Tx Offsets To Apply Remaining",
@@ -892,7 +892,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_BLOCK_PUMP\"}) - sum(contract_summary_topic_current_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_BLOCK_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_BLOCK_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-contract-summary-update-process\",topic=\"ETHEREUM_BLOCK_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Block Offsets To Apply Remaining",
@@ -973,7 +973,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_UNCLE_PUMP\"}) - sum(contract_summary_topic_current_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_UNCLE_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_UNCLE_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-contract-summary-update-process\",topic=\"ETHEREUM_UNCLE_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Uncle Offsets To Apply Remaining",

--- a/kubernetes-definitions/monitoring/dashboards/ethereum/ETH_Dump.json
+++ b/kubernetes-definitions/monitoring/dashboards/ethereum/ETH_Dump.json
@@ -88,23 +88,22 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(dump_topic_current_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_TX_PUMP\"})",
+          "expr": "sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-txs-dump-process\",topic=\"ETHEREUM_TX_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Current Dump Tx Offset",
           "refId": "A"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_TX_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_TX_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Last Dump Tx Offset",
           "refId": "B"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_TX_PUMP\"}) - sum(dump_topic_current_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_TX_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_TX_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-txs-dump-process\",topic=\"ETHEREUM_TX_PUMP\"})",
           "format": "time_series",
-          "hide": true,
           "intervalFactor": 1,
           "refId": "C"
         }
@@ -154,250 +153,6 @@
       ]
     },
     {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": true,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "PROMETHEUS",
-      "format": "short",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 12,
-        "y": 0
-      },
-      "id": 8,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "Remaining",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_TX_PUMP\"}) - sum(dump_topic_current_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_TX_PUMP\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Tx Offsets To Dump Remaining",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "100,1000",
-      "title": "Tx Offsets To Dump Remaining",
-      "type": "singlestat",
-      "valueFontSize": "50%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": true,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "PROMETHEUS",
-      "format": "short",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 16,
-        "y": 0
-      },
-      "id": 10,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "Remaining",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_BLOCK_PUMP\"}) - sum(dump_topic_current_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_BLOCK_PUMP\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Block Offsets To Dump Remaining",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "1,5",
-      "title": "Block Offsets To Dump Remaining",
-      "type": "singlestat",
-      "valueFontSize": "50%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": true,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "PROMETHEUS",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 20,
-        "y": 0
-      },
-      "id": 12,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "Remaining",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_UNCLE_PUMP\"}) - sum(dump_topic_current_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_UNCLE_PUMP\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Uncle Offsets To Dump Remaining",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "1,5",
-      "timeShift": null,
-      "title": "Uncle Offsets To Dump Remaining",
-      "type": "singlestat",
-      "valueFontSize": "50%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
       "alert": {
         "conditions": [
           {
@@ -441,7 +196,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 3
+        "y": 0
       },
       "id": 2,
       "legend": {
@@ -468,21 +223,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(dump_topic_current_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_UNCLE_PUMP\"})",
+          "expr": "sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-uncles-dump-process\",topic=\"ETHEREUM_UNCLE_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Current Dump Uncle Offset",
           "refId": "A"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_UNCLE_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_UNCLE_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Last Uncle Offset",
           "refId": "B"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_UNCLE_PUMP\"}) - sum(dump_topic_current_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_UNCLE_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_UNCLE_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-uncles-dump-process\",topic=\"ETHEREUM_UNCLE_PUMP\"})",
           "format": "time_series",
           "hide": true,
           "intervalFactor": 1,
@@ -605,21 +360,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(dump_topic_current_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_BLOCK_PUMP\"})",
+          "expr": "sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-blocks-dump-process\",topic=\"ETHEREUM_BLOCK_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Current Dump Block Offset",
           "refId": "A"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_BLOCK_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_BLOCK_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Last Block Offset",
           "refId": "B"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_BLOCK_PUMP\"}) - sum(dump_topic_current_offset{chain=\"ETHEREUM\",topic=\"ETHEREUM_BLOCK_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_BLOCK_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-blocks-dump-process\",topic=\"ETHEREUM_BLOCK_PUMP\"})",
           "format": "time_series",
           "hide": true,
           "intervalFactor": 1,

--- a/kubernetes-definitions/monitoring/dashboards/ethereum_classic/ETC_Contract_Summary.json
+++ b/kubernetes-definitions/monitoring/dashboards/ethereum_classic/ETC_Contract_Summary.json
@@ -168,7 +168,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(contract_summary_topic_current_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_TX_PUMP\"})",
+          "expr": "sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-contract-summary-update-process\",topic=\"ETHEREUM_CLASSIC_TX_PUMP\"})",
           "format": "time_series",
           "interval": "20s",
           "intervalFactor": 1,
@@ -176,7 +176,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_TX_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_CLASSIC_TX_PUMP\"})",
           "format": "time_series",
           "interval": "20s",
           "intervalFactor": 1,
@@ -184,7 +184,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_TX_PUMP\"}) - sum(contract_summary_topic_current_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_TX_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_CLASSIC_TX_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-contract-summary-update-process\",topic=\"ETHEREUM_CLASSIC_TX_PUMP\"})",
           "format": "time_series",
           "hide": true,
           "intervalFactor": 1,
@@ -306,21 +306,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(contract_summary_topic_current_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_BLOCK_PUMP\"})",
+          "expr": "sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-contract-summary-update-process\",topic=\"ETHEREUM_CLASSIC_BLOCK_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Current Contract Summary Block Offset",
           "refId": "A"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_BLOCK_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_CLASSIC_BLOCK_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Last Contract Summary Ethereum Classic Block Offset",
           "refId": "B"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_BLOCK_PUMP\"}) - sum(contract_summary_topic_current_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_BLOCK_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_CLASSIC_BLOCK_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-contract-summary-update-process\",topic=\"ETHEREUM_CLASSIC_BLOCK_PUMP\"})",
           "format": "time_series",
           "hide": true,
           "intervalFactor": 1,
@@ -442,21 +442,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(contract_summary_topic_current_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_UNCLE_PUMP\"})",
+          "expr": "sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-contract-summary-update-process\",topic=\"ETHEREUM_CLASSIC_UNCLE_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Current Contract Summary Uncle Offset",
           "refId": "A"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_UNCLE_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_CLASSIC_UNCLE_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Last Contract Summary Uncle Offset",
           "refId": "B"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_UNCLE_PUMP\"}) - sum(contract_summary_topic_current_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_UNCLE_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_CLASSIC_UNCLE_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-contract-summary-update-process\",topic=\"ETHEREUM_CLASSIC_UNCLE_PUMP\"})",
           "format": "time_series",
           "hide": true,
           "intervalFactor": 1,
@@ -811,7 +811,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_TX_PUMP\"}) - sum(contract_summary_topic_current_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_TX_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_CLASSIC_TX_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-contract-summary-update-process\",topic=\"ETHEREUM_CLASSIC_TX_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Tx Offsets To Apply Remaining",
@@ -892,7 +892,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_BLOCK_PUMP\"}) - sum(contract_summary_topic_current_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_BLOCK_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_CLASSIC_BLOCK_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-contract-summary-update-process\",topic=\"ETHEREUM_CLASSIC_BLOCK_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Block Offsets To Apply Remaining",
@@ -973,7 +973,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_UNCLE_PUMP\"}) - sum(contract_summary_topic_current_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_UNCLE_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_CLASSIC_UNCLE_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-contract-summary-update-process\",topic=\"ETHEREUM_CLASSIC_UNCLE_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Uncle Offsets To Apply Remaining",

--- a/kubernetes-definitions/monitoring/dashboards/ethereum_classic/ETC_Dump.json
+++ b/kubernetes-definitions/monitoring/dashboards/ethereum_classic/ETC_Dump.json
@@ -88,23 +88,22 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(dump_topic_current_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_TX_PUMP\"})",
+          "expr": "sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-txs-dump-process\",topic=\"ETHEREUM_TX_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Current Dump Tx Offset",
           "refId": "A"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_TX_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_TX_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Last Dump Tx Offset",
           "refId": "B"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_TX_PUMP\"}) - sum(dump_topic_current_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_TX_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_TX_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-txs-dump-process\",topic=\"ETHEREUM_TX_PUMP\"})",
           "format": "time_series",
-          "hide": true,
           "intervalFactor": 1,
           "refId": "C"
         }
@@ -154,250 +153,6 @@
       ]
     },
     {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": true,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "PROMETHEUS",
-      "format": "short",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 12,
-        "y": 0
-      },
-      "id": 8,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "Remaining",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_TX_PUMP\"}) - sum(dump_topic_current_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_TX_PUMP\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Tx Offsets To Dump Remaining",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "100,1000",
-      "title": "Tx Offsets To Dump Remaining",
-      "type": "singlestat",
-      "valueFontSize": "50%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": true,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "PROMETHEUS",
-      "format": "short",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 16,
-        "y": 0
-      },
-      "id": 10,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "Remaining",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_BLOCK_PUMP\"}) - sum(dump_topic_current_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_BLOCK_PUMP\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Block Offsets To Dump Remaining",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "1,5",
-      "title": "Block Offsets To Dump Remaining",
-      "type": "singlestat",
-      "valueFontSize": "50%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": true,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "PROMETHEUS",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 20,
-        "y": 0
-      },
-      "id": 12,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "Remaining",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_UNCLE_PUMP\"}) - sum(dump_topic_current_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_UNCLE_PUMP\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Uncle Offsets To Dump Remaining",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "1,5",
-      "timeShift": null,
-      "title": "Uncle Offsets To Dump Remaining",
-      "type": "singlestat",
-      "valueFontSize": "50%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
       "alert": {
         "conditions": [
           {
@@ -441,7 +196,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 3
+        "y": 0
       },
       "id": 2,
       "legend": {
@@ -468,21 +223,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(dump_topic_current_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_UNCLE_PUMP\"})",
+          "expr": "sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-uncles-dump-process\",topic=\"ETHEREUM_UNCLE_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Current Dump Uncle Offset",
           "refId": "A"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_UNCLE_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_UNCLE_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Last Uncle Offset",
           "refId": "B"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_UNCLE_PUMP\"}) - sum(dump_topic_current_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_UNCLE_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_UNCLE_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-uncles-dump-process\",topic=\"ETHEREUM_UNCLE_PUMP\"})",
           "format": "time_series",
           "hide": true,
           "intervalFactor": 1,
@@ -605,21 +360,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(dump_topic_current_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_BLOCK_PUMP\"})",
+          "expr": "sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-blocks-dump-process\",topic=\"ETHEREUM_BLOCK_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Current Dump Block Offset",
           "refId": "A"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_BLOCK_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_BLOCK_PUMP\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Last Block Offset",
           "refId": "B"
         },
         {
-          "expr": "sum(pump_topic_last_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_BLOCK_PUMP\"}) - sum(dump_topic_current_offset{chain=\"ETHEREUM_CLASSIC\",topic=\"ETHEREUM_CLASSIC_BLOCK_PUMP\"})",
+          "expr": "sum(kafka_topic_partition_current_offset{topic=\"ETHEREUM_BLOCK_PUMP\"}) - sum(kafka_consumergroup_current_offset{consumergroup=\"ethereum-blocks-dump-process\",topic=\"ETHEREUM_BLOCK_PUMP\"})",
           "format": "time_series",
           "hide": true,
           "intervalFactor": 1,


### PR DESCRIPTION
Migrate search kafka monitoring info to kafka exporter metrics.
Prometheus functions changed for ETC, ETH Dump/Contract Summary. 
Changed BTC Dump dashboard:
![grafana-btc-dump](https://user-images.githubusercontent.com/7107023/39996869-9f304c78-5789-11e8-8d2f-747e618ef4af.png)
Changed BTC Contract Summary dashboard:
![grafana-btc-cs](https://user-images.githubusercontent.com/7107023/39996890-af6c231e-5789-11e8-858f-6a1a9fac140b.png)
Changed BTC Pump dashboard. Added cache monitoring:
![grafana-cache](https://user-images.githubusercontent.com/7107023/39996911-c19f2360-5789-11e8-8d02-41517a1ea4b0.png)